### PR TITLE
fix: fix autocli commands of operators and services modules

### DIFF
--- a/x/operators/autocli.go
+++ b/x/operators/autocli.go
@@ -56,7 +56,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "RegisterOperator",
 					Use:       "register [moniker]",
 					Short:     "Register a new operator",
-					Long: `Register a new operator having the given name. 
+					Long: `Register a new operator having the given name.
 
 You can specify a website and a picture URL using the optional flags.
 The operator will be created with the sender as the admin.`,
@@ -68,15 +68,15 @@ The operator will be created with the sender as the admin.`,
 						{ProtoField: "moniker"},
 					},
 					FlagOptions: map[string]*autocliv1.FlagOptions{
-						"website":     {DefaultValue: types.DoNotModify},
-						"picture_url": {DefaultValue: types.DoNotModify},
+						"website":     {Usage: "website URL of the operator"},
+						"picture_url": {Usage: "picture URL of the operator"},
 					},
 				},
 				{
 					RpcMethod: "UpdateOperator",
-					Use:       "edit [operator-id]",
-					Short:     "Edit an existing operator",
-					Long: `Edit an existing operator having the provided it. 
+					Use:       "update [operator-id]",
+					Short:     "Update an existing operator",
+					Long: `Update an existing operator having the provided it.
 
 You can specify the moniker, website and picture URL using the optional flags.
 Only the fields that you provide will be updated`,
@@ -88,9 +88,18 @@ Only the fields that you provide will be updated`,
 						{ProtoField: "operator_id"},
 					},
 					FlagOptions: map[string]*autocliv1.FlagOptions{
-						"moniker":     {DefaultValue: types.DoNotModify},
-						"website":     {DefaultValue: types.DoNotModify},
-						"picture_url": {DefaultValue: types.DoNotModify},
+						"moniker": {
+							Usage:        "moniker of the operator",
+							DefaultValue: types.DoNotModify,
+						},
+						"website": {
+							Usage:        "website URL of the operator",
+							DefaultValue: types.DoNotModify,
+						},
+						"picture_url": {
+							Usage:        "picture URL of the operator",
+							DefaultValue: types.DoNotModify,
+						},
 					},
 				},
 				{

--- a/x/operators/client/cli/tx.go
+++ b/x/operators/client/cli/tx.go
@@ -31,7 +31,8 @@ func GetTxCmd() *cobra.Command {
 	return txCmd
 }
 
-// GetCmdSetOperatorParams returns the command allowing to edit an existing operator
+// GetCmdSetOperatorParams returns the command allowing to set an existing operator's
+// parameters
 func GetCmdSetOperatorParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set-params [operator-id] [commission-rate]",

--- a/x/services/autocli.go
+++ b/x/services/autocli.go
@@ -57,6 +57,11 @@ The service will be created with the sender as the owner.`,
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "name"},
 					},
+					FlagOptions: map[string]*autocliv1.FlagOptions{
+						"description": {Usage: "description of the service"},
+						"website":     {Usage: "website URL of the service"},
+						"picture_url": {Usage: "picture URL of the service"},
+					},
 				},
 				{
 					RpcMethod: "UpdateService",
@@ -64,7 +69,7 @@ The service will be created with the sender as the owner.`,
 					Short:     "Update an existing service",
 					Long: `Update an existing service having the provided it. 
 
-You can specify a description, website and a picture URL using the optional flags.
+You can specify a name, description, website and a picture URL using the optional flags.
 Only the fields that you provide will be updated`,
 					Example: fmt.Sprintf(
 						`%s tx %s update 1 --description "My new description" --from alice`,
@@ -74,10 +79,22 @@ Only the fields that you provide will be updated`,
 						{ProtoField: "service_id"},
 					},
 					FlagOptions: map[string]*autocliv1.FlagOptions{
-						"name":        {DefaultValue: types.DoNotModify},
-						"description": {DefaultValue: types.DoNotModify},
-						"website":     {DefaultValue: types.DoNotModify},
-						"picture_url": {DefaultValue: types.DoNotModify},
+						"name": {
+							Usage:        "name of the service",
+							DefaultValue: types.DoNotModify,
+						},
+						"description": {
+							Usage:        "description of the service",
+							DefaultValue: types.DoNotModify,
+						},
+						"website": {
+							Usage:        "website URL of the service",
+							DefaultValue: types.DoNotModify,
+						},
+						"picture_url": {
+							Usage:        "picture URL of the service",
+							DefaultValue: types.DoNotModify,
+						},
 					},
 				},
 				{


### PR DESCRIPTION
## Description

it's impossible to set `website` and `picture_url` as `"[do-not-modify]"` when registering an operator

also use consistent command name for `UpdateOperator`(edit -> update) and add meaningful flag usages

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)