### PR TITLE
refactor: apply Cosmos SDK v0.50 conventions

### DIFF
--- a/.changeset/entries/861a96d7026170f055a293299b782c79785a8c6c3f7034ebe62f3ea878266583.yaml
+++ b/.changeset/entries/861a96d7026170f055a293299b782c79785a8c6c3f7034ebe62f3ea878266583.yaml
@@ -1,0 +1,6 @@
+type: refactor
+module: none
+pull_request: 208
+description: Apply Cosmos SDK v0.50 conventions
+backward_compatible: true
+date: 2024-12-10T08:38:13.018999Z

--- a/x/assets/keeper/keeper.go
+++ b/x/assets/keeper/keeper.go
@@ -13,8 +13,7 @@ import (
 )
 
 type Keeper struct {
-	cdc          codec.Codec
-	storeService corestoretypes.KVStoreService
+	cdc codec.Codec
 
 	Schema        collections.Schema
 	Assets        collections.Map[string, types.Asset]                 // denom => types.Asset
@@ -30,8 +29,7 @@ func NewKeeper(
 ) *Keeper {
 	sb := collections.NewSchemaBuilder(storeService)
 	k := &Keeper{
-		cdc:          cdc,
-		storeService: storeService,
+		cdc: cdc,
 
 		Assets: collections.NewMap(
 			sb,

--- a/x/liquidvesting/keeper/send_restriction_test.go
+++ b/x/liquidvesting/keeper/send_restriction_test.go
@@ -81,9 +81,8 @@ func (suite *KeeperTestSuite) TestKeeper_BankSend() {
 				lockedDenom, err := types.GetLockedRepresentationDenom("stake")
 				suite.Require().NoError(err)
 
-				pool, found, err := suite.pk.GetPool(ctx, 1)
+				pool, err := suite.pk.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 
 				poolCoins := suite.bk.GetAllBalances(ctx, sdk.MustAccAddressFromBech32(pool.GetAddress()))
 				suite.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin(lockedDenom, 1000)), poolCoins)
@@ -126,9 +125,8 @@ func (suite *KeeperTestSuite) TestKeeper_BankSend() {
 				lockedDenom, err := types.GetLockedRepresentationDenom("stake")
 				suite.Require().NoError(err)
 
-				operator, found, err := suite.ok.GetOperator(ctx, 1)
+				operator, err := suite.ok.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 
 				poolCoins := suite.bk.GetAllBalances(ctx, sdk.MustAccAddressFromBech32(operator.GetAddress()))
 				suite.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin(lockedDenom, 1000)), poolCoins)
@@ -173,9 +171,8 @@ func (suite *KeeperTestSuite) TestKeeper_BankSend() {
 				lockedDenom, err := types.GetLockedRepresentationDenom("stake")
 				suite.Require().NoError(err)
 
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 
 				poolCoins := suite.bk.GetAllBalances(ctx, sdk.MustAccAddressFromBech32(service.GetAddress()))
 				suite.Require().Equal(sdk.NewCoins(sdk.NewInt64Coin(lockedDenom, 1000)), poolCoins)

--- a/x/operators/abci_test.go
+++ b/x/operators/abci_test.go
@@ -78,9 +78,8 @@ func TestBeginBlocker(t *testing.T) {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator is still inactivating
-				operator, found, err := operatorsKeeper.GetOperator(ctx, 1)
+				operator, err := operatorsKeeper.GetOperator(ctx, 1)
 				require.NoError(t, err)
-				require.True(t, found)
 				require.Equal(t, types.OPERATOR_STATUS_INACTIVATING, operator.Status)
 
 				// Make sure the operator is still in the inactivating queue
@@ -116,9 +115,8 @@ func TestBeginBlocker(t *testing.T) {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator is inactive
-				operator, found, err := operatorsKeeper.GetOperator(ctx, 1)
+				operator, err := operatorsKeeper.GetOperator(ctx, 1)
 				require.NoError(t, err)
-				require.True(t, found)
 				require.Equal(t, types.OPERATOR_STATUS_INACTIVE, operator.Status)
 
 				// Make sure the operator is not in the inactivating queue

--- a/x/operators/keeper/alias_functions.go
+++ b/x/operators/keeper/alias_functions.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"cosmossdk.io/collections"
@@ -49,7 +48,7 @@ func (k *Keeper) IterateInactivatingOperatorQueue(ctx context.Context, endTime t
 		operator, err := k.GetOperator(ctx, operatorID)
 		if err != nil {
 			if errors.Is(err, collections.ErrNotFound) {
-				return true, fmt.Errorf("operator %d does not exist", operatorID)
+				return true, types.ErrOperatorNotFound
 			}
 			return true, err
 		}

--- a/x/operators/keeper/alias_functions.go
+++ b/x/operators/keeper/alias_functions.go
@@ -23,29 +23,10 @@ func (k *Keeper) createAccountIfNotExists(ctx context.Context, address sdk.AccAd
 
 // IterateOperators iterates over the operators in the store and performs a callback function
 func (k *Keeper) IterateOperators(ctx context.Context, cb func(operator types.Operator) (stop bool, err error)) error {
-	iterator, err := k.operators.Iterate(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		operator, err := iterator.Value()
-		if err != nil {
-			return err
-		}
-
-		stop, err := cb(operator)
-		if err != nil {
-			return err
-		}
-
-		if stop {
-			break
-		}
-	}
-
-	return nil
+	err := k.operators.Walk(ctx, nil, func(_ uint32, operator types.Operator) (stop bool, err error) {
+		return cb(operator)
+	})
+	return err
 }
 
 // GetOperators returns the operators stored in the KVStore
@@ -126,26 +107,13 @@ func (k *Keeper) IsOperatorAddress(ctx context.Context, address string) (bool, e
 
 // GetAllOperatorParamsRecords returns all the operator params records
 func (k *Keeper) GetAllOperatorParamsRecords(ctx context.Context) ([]types.OperatorParamsRecord, error) {
-	iterator, err := k.operatorParams.Iterate(ctx, nil)
+	var records []types.OperatorParamsRecord
+	err := k.operatorParams.Walk(ctx, nil, func(operatorID uint32, params types.OperatorParams) (stop bool, err error) {
+		records = append(records, types.NewOperatorParamsRecord(operatorID, params))
+		return false, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer iterator.Close()
-
-	var records []types.OperatorParamsRecord
-	for ; iterator.Valid(); iterator.Next() {
-		// Get the operator params
-		params, err := iterator.Value()
-		if err != nil {
-			return nil, err
-		}
-		// Get the operator id from the map key
-		operatorID, err := iterator.Key()
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, types.NewOperatorParamsRecord(operatorID, params))
-	}
-
 	return records, nil
 }

--- a/x/operators/keeper/genesis.go
+++ b/x/operators/keeper/genesis.go
@@ -1,8 +1,10 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/milkyway-labs/milkyway/v3/x/operators/types"
@@ -65,13 +67,12 @@ func (k *Keeper) InitGenesis(ctx sdk.Context, state *types.GenesisState) error {
 	// Store the operator params
 	for _, operatorParams := range state.OperatorsParams {
 		// Ensure that the operator is present
-		_, found, err := k.GetOperator(ctx, operatorParams.OperatorID)
+		_, err := k.GetOperator(ctx, operatorParams.OperatorID)
 		if err != nil {
+			if errors.Is(err, collections.ErrNotFound) {
+				return fmt.Errorf("can't set operator params for %d, operator not found", operatorParams.OperatorID)
+			}
 			return err
-		}
-
-		if !found {
-			return fmt.Errorf("can't set operator params for %d, operator not found", operatorParams.OperatorID)
 		}
 
 		err = k.SaveOperatorParams(ctx, operatorParams.OperatorID, operatorParams.Params)

--- a/x/operators/keeper/genesis.go
+++ b/x/operators/keeper/genesis.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"errors"
-	"fmt"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/milkyway-labs/milkyway/v3/x/operators/types"
@@ -70,7 +70,7 @@ func (k *Keeper) InitGenesis(ctx sdk.Context, state *types.GenesisState) error {
 		_, err := k.GetOperator(ctx, operatorParams.OperatorID)
 		if err != nil {
 			if errors.Is(err, collections.ErrNotFound) {
-				return fmt.Errorf("can't set operator params for %d, operator not found", operatorParams.OperatorID)
+				return errorsmod.Wrapf(types.ErrOperatorNotFound, "operator %d not found", operatorParams.OperatorID)
 			}
 			return err
 		}

--- a/x/operators/keeper/genesis_test.go
+++ b/x/operators/keeper/genesis_test.go
@@ -289,9 +289,8 @@ func (suite *KeeperTestSuite) TestKeeper_InitGenesis() {
 				Params: types.DefaultParams(),
 			},
 			check: func(ctx sdk.Context) {
-				operator, found, err := suite.k.GetOperator(ctx, 1)
+				operator, err := suite.k.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					1,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -305,9 +304,8 @@ func (suite *KeeperTestSuite) TestKeeper_InitGenesis() {
 				params, err := suite.k.GetOperatorParams(ctx, 1)
 				suite.Require().Equal(types.DefaultOperatorParams(), params)
 
-				operator, found, err = suite.k.GetOperator(ctx, 2)
+				operator, err = suite.k.GetOperator(ctx, 2)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					2,
 					types.OPERATOR_STATUS_INACTIVATING,

--- a/x/operators/keeper/grpc_query.go
+++ b/x/operators/keeper/grpc_query.go
@@ -2,7 +2,9 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
+	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -14,13 +16,12 @@ var _ types.QueryServer = &Keeper{}
 
 // Operator implements the Query/Operator gRPC method
 func (k *Keeper) Operator(ctx context.Context, request *types.QueryOperatorRequest) (*types.QueryOperatorResponse, error) {
-	operator, found, err := k.GetOperator(ctx, request.OperatorId)
+	operator, err := k.GetOperator(ctx, request.OperatorId)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "operator not found")
+		}
 		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if !found {
-		return nil, status.Error(codes.NotFound, "operator not found")
 	}
 
 	return &types.QueryOperatorResponse{Operator: operator}, nil
@@ -41,13 +42,12 @@ func (k *Keeper) Operators(ctx context.Context, request *types.QueryOperatorsReq
 }
 
 func (k *Keeper) OperatorParams(ctx context.Context, request *types.QueryOperatorParamsRequest) (*types.QueryOperatorParamsResponse, error) {
-	_, found, err := k.GetOperator(ctx, request.OperatorId)
+	_, err := k.GetOperator(ctx, request.OperatorId)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "operator not found")
+		}
 		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	params, err := k.GetOperatorParams(ctx, request.OperatorId)

--- a/x/operators/keeper/msg_server.go
+++ b/x/operators/keeper/msg_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -98,13 +99,12 @@ func (k msgServer) RegisterOperator(ctx context.Context, msg *types.MsgRegisterO
 // UpdateOperator defines the rpc method for Msg/UpdateOperator
 func (k msgServer) UpdateOperator(ctx context.Context, msg *types.MsgUpdateOperator) (*types.MsgUpdateOperatorResponse, error) {
 	// Check if the operator exists
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can update the operator
@@ -141,13 +141,12 @@ func (k msgServer) UpdateOperator(ctx context.Context, msg *types.MsgUpdateOpera
 // DeactivateOperator defines the rpc method for Msg/DeactivateOperator
 func (k msgServer) DeactivateOperator(ctx context.Context, msg *types.MsgDeactivateOperator) (*types.MsgDeactivateOperatorResponse, error) {
 	// Check if the operator exists
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can deactivate the operator
@@ -175,13 +174,12 @@ func (k msgServer) DeactivateOperator(ctx context.Context, msg *types.MsgDeactiv
 // ReactivateOperator defines the rpc method for Msg/ReactivateOperator
 func (k msgServer) ReactivateOperator(ctx context.Context, msg *types.MsgReactivateOperator) (*types.MsgReactivateOperatorResponse, error) {
 	// Check if the operator exists
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can reactivate the operator
@@ -209,13 +207,12 @@ func (k msgServer) ReactivateOperator(ctx context.Context, msg *types.MsgReactiv
 // DeleteOperator defines the rpc method for Msg/DeleteOperator
 func (k msgServer) DeleteOperator(ctx context.Context, msg *types.MsgDeleteOperator) (*types.MsgDeleteOperatorResponse, error) {
 	// Check if the operator exists
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can delete the operator
@@ -243,13 +240,12 @@ func (k msgServer) DeleteOperator(ctx context.Context, msg *types.MsgDeleteOpera
 // TransferOperatorOwnership defines the rpc method for Msg/TransferOperatorOwnership
 func (k msgServer) TransferOperatorOwnership(ctx context.Context, msg *types.MsgTransferOperatorOwnership) (*types.MsgTransferOperatorOwnershipResponse, error) {
 	// Check if the operator exists
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can transfer the operator ownership
@@ -278,13 +274,12 @@ func (k msgServer) TransferOperatorOwnership(ctx context.Context, msg *types.Msg
 
 // SetOperatorParams defines the rpc method for Msg/SetOperatorParams
 func (k msgServer) SetOperatorParams(ctx context.Context, msg *types.MsgSetOperatorParams) (*types.MsgSetOperatorParamsResponse, error) {
-	operator, found, err := k.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrOperatorNotFound
 	}
 
 	// Make sure only the admin can update the operator

--- a/x/operators/keeper/msg_server_test.go
+++ b/x/operators/keeper/msg_server_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"time"
 
+	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -122,9 +123,8 @@ func (suite *KeeperTestSuite) TestMsgServer_RegisterOperator() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was stored
-				stored, found, err := suite.k.GetOperator(ctx, 2)
+				stored, err := suite.k.GetOperator(ctx, 2)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					2,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -210,9 +210,8 @@ func (suite *KeeperTestSuite) TestMsgServer_RegisterOperator() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was stored
-				stored, found, err := suite.k.GetOperator(ctx, 2)
+				stored, err := suite.k.GetOperator(ctx, 2)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					2,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -387,9 +386,8 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateOperator() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was updated
-				stored, found, err := suite.k.GetOperator(ctx, 1)
+				stored, err := suite.k.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					1,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -548,9 +546,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeactivateOperator() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was updated
-				stored, found, err := suite.k.GetOperator(ctx, 1)
+				stored, err := suite.k.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					1,
 					types.OPERATOR_STATUS_INACTIVATING,
@@ -703,9 +700,8 @@ func (suite *KeeperTestSuite) TestMsgServer_ReactivateOperator() {
 				),
 			},
 			check: func(ctx sdk.Context) {
-				operator, found, err := suite.k.GetOperator(ctx, 1)
+				operator, err := suite.k.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					1,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -823,9 +819,8 @@ func (suite *KeeperTestSuite) TestMsgServer_TransferOperatorOwnership() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was updated
-				stored, found, err := suite.k.GetOperator(ctx, 1)
+				stored, err := suite.k.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewOperator(
 					1,
 					types.OPERATOR_STATUS_ACTIVE,
@@ -971,9 +966,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteOperator() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the operator was updated
-				_, found, err := suite.k.GetOperator(ctx, 1)
-				suite.Require().NoError(err)
-				suite.Require().False(found)
+				_, err := suite.k.GetOperator(ctx, 1)
+				suite.Require().ErrorIs(err, collections.ErrNotFound)
 
 				// Ensure the hook has been called
 				suite.Require().True(suite.hooks.CalledMap["BeforeOperatorDeleted"])

--- a/x/operators/keeper/operators.go
+++ b/x/operators/keeper/operators.go
@@ -56,15 +56,8 @@ func (k *Keeper) CreateOperator(ctx context.Context, operator types.Operator) er
 
 // GetOperator returns the operator with the given ID.
 // If the operator does not exist, false is returned.
-func (k *Keeper) GetOperator(ctx context.Context, operatorID uint32) (operator types.Operator, found bool, err error) {
-	operator, err = k.operators.Get(ctx, operatorID)
-	if err != nil {
-		if errors.IsOf(err, collections.ErrNotFound) {
-			return types.Operator{}, false, nil
-		}
-		return types.Operator{}, false, err
-	}
-	return operator, true, nil
+func (k *Keeper) GetOperator(ctx context.Context, operatorID uint32) (operator types.Operator, err error) {
+	return k.operators.Get(ctx, operatorID)
 }
 
 // SaveOperator stores the given operator in the KVStore

--- a/x/pools/keeper/grpc_query.go
+++ b/x/pools/keeper/grpc_query.go
@@ -2,7 +2,9 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
+	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
@@ -19,13 +21,12 @@ func (k *Keeper) PoolByID(ctx context.Context, request *types.QueryPoolByIdReque
 		return nil, status.Error(codes.InvalidArgument, "invalid pool id")
 	}
 
-	pool, found, err := k.GetPool(ctx, request.PoolId)
+	pool, err := k.GetPool(ctx, request.PoolId)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "pool not found")
+		}
 		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if !found {
-		return nil, status.Error(codes.NotFound, "pool not found")
 	}
 
 	return &types.QueryPoolResponse{Pool: pool}, nil

--- a/x/pools/keeper/grpc_query.go
+++ b/x/pools/keeper/grpc_query.go
@@ -51,8 +51,8 @@ func (k *Keeper) PoolByDenom(ctx context.Context, request *types.QueryPoolByDeno
 
 // Pools implements the Query/Pools gRPC method
 func (k *Keeper) Pools(ctx context.Context, request *types.QueryPoolsRequest) (*types.QueryPoolsResponse, error) {
-	pools, pageRes, err := query.CollectionPaginate(ctx, k.pools, request.Pagination, func(key uint32, value types.Pool) (types.Pool, error) {
-		return value, nil
+	pools, pageRes, err := query.CollectionPaginate(ctx, k.pools, request.Pagination, func(_ uint32, pool types.Pool) (types.Pool, error) {
+		return pool, nil
 	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/x/pools/keeper/keeper.go
+++ b/x/pools/keeper/keeper.go
@@ -13,9 +13,8 @@ import (
 )
 
 type Keeper struct {
-	cdc          codec.Codec
-	storeService corestoretypes.KVStoreService
-	hooks        types.PoolsHooks
+	cdc   codec.Codec
+	hooks types.PoolsHooks
 
 	accountKeeper types.AccountKeeper
 
@@ -33,7 +32,6 @@ func NewKeeper(cdc codec.Codec,
 
 	k := &Keeper{
 		cdc:           cdc,
-		storeService:  storeService,
 		accountKeeper: accountKeeper,
 
 		nextPoolID: collections.NewSequence(

--- a/x/pools/keeper/pools.go
+++ b/x/pools/keeper/pools.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -52,13 +51,6 @@ func (k *Keeper) SavePool(ctx context.Context, pool types.Pool) error {
 
 // GetPool retrieves the pool with the given ID from the store.
 // If the pool does not exist, false is returned instead
-func (k *Keeper) GetPool(ctx context.Context, id uint32) (types.Pool, bool, error) {
-	pool, err := k.pools.Get(ctx, id)
-	if err != nil {
-		if errors.IsOf(err, collections.ErrNotFound) {
-			return types.Pool{}, false, nil
-		}
-		return types.Pool{}, false, err
-	}
-	return pool, true, nil
+func (k *Keeper) GetPool(ctx context.Context, id uint32) (types.Pool, error) {
+	return k.pools.Get(ctx, id)
 }

--- a/x/pools/keeper/pools_test.go
+++ b/x/pools/keeper/pools_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/milkyway-labs/milkyway/v3/x/pools/types"
@@ -124,9 +125,8 @@ func (suite *KeeperTestSuite) TestKeeper_SavePool() {
 			pool:      types.NewPool(1, "uatom"),
 			check: func(ctx sdk.Context) {
 				// Make sure the pool is saved properly
-				pool, found, err := suite.k.GetPool(ctx, 1)
+				pool, err := suite.k.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewPool(1, "uatom"), pool)
 
 				// Make sure the pool account is created
@@ -147,9 +147,8 @@ func (suite *KeeperTestSuite) TestKeeper_SavePool() {
 			shouldErr: false,
 			check: func(ctx sdk.Context) {
 				// Make sure the pool is saved properly
-				pool, found, err := suite.k.GetPool(ctx, 1)
+				pool, err := suite.k.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewPool(1, "usdt"), pool)
 
 				// Make sure the pool account is created
@@ -186,14 +185,13 @@ func (suite *KeeperTestSuite) TestKeeper_SavePool() {
 
 func (suite *KeeperTestSuite) TestKeeper_GetPool() {
 	testCases := []struct {
-		name      string
-		setup     func()
-		store     func(ctx sdk.Context)
-		poolID    uint32
-		shouldErr bool
-		expFound  bool
-		expPool   types.Pool
-		check     func(ctx sdk.Context)
+		name     string
+		setup    func()
+		store    func(ctx sdk.Context)
+		poolID   uint32
+		expFound bool
+		expPool  types.Pool
+		check    func(ctx sdk.Context)
 	}{
 		{
 			name:     "not found pool returns error",
@@ -223,15 +221,12 @@ func (suite *KeeperTestSuite) TestKeeper_GetPool() {
 				tc.store(ctx)
 			}
 
-			pool, found, err := suite.k.GetPool(ctx, tc.poolID)
-			if tc.shouldErr {
-				suite.Require().Error(err)
-			} else {
+			pool, err := suite.k.GetPool(ctx, tc.poolID)
+			if tc.expFound {
 				suite.Require().NoError(err)
-				suite.Require().Equal(tc.expFound, found)
-				if tc.expFound {
-					suite.Require().Equal(tc.expPool, pool)
-				}
+				suite.Require().Equal(tc.expPool, pool)
+			} else {
+				suite.Require().ErrorIs(err, collections.ErrNotFound)
 			}
 
 			if tc.check != nil {

--- a/x/restaking/keeper/alias_functions_test.go
+++ b/x/restaking/keeper/alias_functions_test.go
@@ -812,7 +812,7 @@ func (suite *KeeperTestSuite) TestKeeper_UnbondRestakedAssets() {
 				suite.Require().NoError(err)
 				suite.Assert().True(found)
 				suite.Assert().Equal(types.DELEGATION_TYPE_OPERATOR, del.Type)
-				operator, _, err := suite.ok.GetOperator(ctx, 1)
+				operator, err := suite.ok.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
 				suite.Assert().Equal(
 					sdk.NewDecCoins(sdk.NewInt64DecCoin("stake", 50)),

--- a/x/restaking/keeper/grpc_query.go
+++ b/x/restaking/keeper/grpc_query.go
@@ -41,7 +41,7 @@ func (k Querier) OperatorJoinedServices(ctx context.Context, req *types.QueryOpe
 	_, err := k.operatorsKeeper.GetOperator(ctx, req.OperatorId)
 	if err != nil {
 		if errors.IsOf(err, collections.ErrNotFound) {
-			return nil, status.Error(codes.InvalidArgument, "operator not found")
+			return nil, status.Error(codes.NotFound, "operator not found")
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -147,8 +147,7 @@ func (k Querier) ServiceOperators(ctx context.Context, req *types.QueryServiceOp
 			operator, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
 			if err != nil {
 				if errors.IsOf(err, collections.ErrNotFound) {
-					return operatorstypes.Operator{}, errors.Wrapf(
-						operatorstypes.ErrOperatorNotFound, "operator %d not found", operatorID)
+					return operatorstypes.Operator{}, status.Errorf(codes.NotFound, "operator %d not found", operatorID)
 				}
 				return operatorstypes.Operator{}, err
 			}

--- a/x/restaking/keeper/operator_restaking.go
+++ b/x/restaking/keeper/operator_restaking.go
@@ -81,13 +81,12 @@ func (k *Keeper) RemoveOperatorDelegation(ctx context.Context, delegation types.
 // DelegateToOperator sends the given amount to the operator account and saves the delegation for the given user
 func (k *Keeper) DelegateToOperator(ctx context.Context, operatorID uint32, amount sdk.Coins, delegator string) (sdk.DecCoins, error) {
 	// Get the operator
-	operator, found, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
+	operator, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return sdk.NewDecCoins(), operatorstypes.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return sdk.NewDecCoins(), operatorstypes.ErrOperatorNotFound
 	}
 
 	restakableDenoms, err := k.GetRestakableDenoms(ctx)
@@ -164,13 +163,12 @@ func (k *Keeper) GetOperatorUnbondingDelegation(ctx context.Context, operatorID 
 // unbonding delegation for the given user
 func (k *Keeper) UndelegateFromOperator(ctx context.Context, operatorID uint32, amount sdk.Coins, delegator string) (time.Time, error) {
 	// Find the operator
-	operator, found, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
+	operator, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return time.Time{}, operatorstypes.ErrOperatorNotFound
+		}
 		return time.Time{}, err
-	}
-
-	if !found {
-		return time.Time{}, operatorstypes.ErrOperatorNotFound
 	}
 
 	// Get the shares

--- a/x/restaking/keeper/operator_restaking_test.go
+++ b/x/restaking/keeper/operator_restaking_test.go
@@ -367,9 +367,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToOperator() {
 			),
 			check: func(ctx sdk.Context) {
 				// Make sure the operator now exists
-				operator, found, err := suite.ok.GetOperator(ctx, 1)
+				operator, err := suite.ok.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(operatorstypes.Operator{
 					ID:      1,
 					Status:  operatorstypes.OPERATOR_STATUS_ACTIVE,
@@ -455,9 +454,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToOperator() {
 			),
 			check: func(ctx sdk.Context) {
 				// Make sure the operator now exists
-				operator, found, err := suite.ok.GetOperator(ctx, 1)
+				operator, err := suite.ok.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(operatorstypes.Operator{
 					ID:      1,
 					Status:  operatorstypes.OPERATOR_STATUS_ACTIVE,
@@ -562,9 +560,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToOperator() {
 			),
 			check: func(ctx sdk.Context) {
 				// Make sure the operator now exists
-				operator, found, err := suite.ok.GetOperator(ctx, 1)
+				operator, err := suite.ok.GetOperator(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(operatorstypes.Operator{
 					ID:      1,
 					Status:  operatorstypes.OPERATOR_STATUS_ACTIVE,

--- a/x/restaking/keeper/operators_hooks.go
+++ b/x/restaking/keeper/operators_hooks.go
@@ -3,11 +3,12 @@ package keeper
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 
 	operatorstypes "github.com/milkyway-labs/milkyway/v3/x/operators/types"
+	servicestypes "github.com/milkyway-labs/milkyway/v3/x/services/types"
 )
 
 var _ operatorstypes.OperatorsHooks = &OperatorsHooks{}
@@ -89,7 +90,7 @@ func (o *OperatorsHooks) removeOperatorFromServicesAllowList(ctx context.Context
 			service, err := o.servicesKeeper.GetService(ctx, serviceID)
 			if err != nil {
 				if errors.Is(err, collections.ErrNotFound) {
-					return fmt.Errorf("service %d not found", serviceID)
+					return errorsmod.Wrapf(servicestypes.ErrServiceNotFound, "service %d not found", serviceID)
 				}
 				return err
 			}

--- a/x/restaking/keeper/operators_hooks.go
+++ b/x/restaking/keeper/operators_hooks.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/collections"
@@ -85,13 +86,12 @@ func (o *OperatorsHooks) removeOperatorFromServicesAllowList(ctx context.Context
 			return err
 		}
 		if !isConfigured {
-			service, found, err := o.servicesKeeper.GetService(ctx, serviceID)
+			service, err := o.servicesKeeper.GetService(ctx, serviceID)
 			if err != nil {
+				if errors.Is(err, collections.ErrNotFound) {
+					return fmt.Errorf("service %d not found", serviceID)
+				}
 				return err
-			}
-
-			if !found {
-				return fmt.Errorf("service %d not found", serviceID)
 			}
 
 			if !service.IsActive() {

--- a/x/restaking/keeper/operators_hooks_test.go
+++ b/x/restaking/keeper/operators_hooks_test.go
@@ -82,9 +82,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().False(joined)
 
 				// Ensure that the service is status has not changed
-				service, found, err := suite.sk.GetService(ctx, 2)
+				service, err := suite.sk.GetService(ctx, 2)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_ACTIVE, service.Status)
 			},
 			operatorID: 1,
@@ -131,9 +130,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().True(joined)
 
 				// Ensure that the service is status has not changed
-				service, found, err := suite.sk.GetService(ctx, 2)
+				service, err := suite.sk.GetService(ctx, 2)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_ACTIVE, service.Status)
 			},
 			operatorID: 1,
@@ -164,9 +162,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().False(joined)
 
 				// Ensure that the service is now inactive
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_INACTIVE, service.Status)
 			},
 			operatorID: 1,
@@ -200,9 +197,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().False(joined)
 
 				// Ensure the service status has not changed
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_ACTIVE, service.Status)
 			},
 			operatorID: 1,
@@ -233,9 +229,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().False(joined)
 
 				// Ensure the service status has not changed
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_CREATED, service.Status)
 			},
 			operatorID: 1,
@@ -266,9 +261,8 @@ func (suite *KeeperTestSuite) TestOperatorHooks_BeforeOperatorDeleted() {
 				suite.Assert().False(joined)
 
 				// Ensure the service status has not changed
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.SERVICE_STATUS_INACTIVE, service.Status)
 			},
 			operatorID: 1,

--- a/x/restaking/keeper/pool_restaking_test.go
+++ b/x/restaking/keeper/pool_restaking_test.go
@@ -308,9 +308,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToPool() {
 			expShares: sdk.NewDecCoins(sdk.NewDecCoinFromDec("pool/1/umilk", sdkmath.LegacyNewDec(100))),
 			check: func(ctx sdk.Context) {
 				// Make sure the pool now exists
-				pool, found, err := suite.pk.GetPool(ctx, 1)
+				pool, err := suite.pk.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(poolstypes.Pool{
 					ID:              1,
 					Denom:           "umilk",
@@ -374,9 +373,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToPool() {
 			expShares: sdk.NewDecCoins(sdk.NewDecCoinFromDec("pool/1/umilk", sdkmath.LegacyNewDec(500))),
 			check: func(ctx sdk.Context) {
 				// Make sure the pool now exists
-				pool, found, err := suite.pk.GetPool(ctx, 1)
+				pool, err := suite.pk.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(poolstypes.Pool{
 					ID:              1,
 					Denom:           "umilk",
@@ -448,9 +446,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToPool() {
 			expShares: sdk.NewDecCoins(sdk.NewDecCoinFromDec("pool/1/umilk", sdkmath.LegacyNewDecWithPrec(15625, 2))),
 			check: func(ctx sdk.Context) {
 				// Make sure the pool now exists
-				pool, found, err := suite.pk.GetPool(ctx, 1)
+				pool, err := suite.pk.GetPool(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(poolstypes.Pool{
 					ID:              1,
 					Denom:           "umilk",

--- a/x/restaking/keeper/service_restaking.go
+++ b/x/restaking/keeper/service_restaking.go
@@ -214,13 +214,12 @@ func (k *Keeper) RemoveServiceDelegation(ctx context.Context, delegation types.D
 // DelegateToService sends the given amount to the service account and saves the delegation for the given user
 func (k *Keeper) DelegateToService(ctx context.Context, serviceID uint32, amount sdk.Coins, delegator string) (sdk.DecCoins, error) {
 	// Get the service
-	service, found, err := k.servicesKeeper.GetService(ctx, serviceID)
+	service, err := k.servicesKeeper.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return sdk.NewDecCoins(), servicestypes.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return sdk.NewDecCoins(), servicestypes.ErrServiceNotFound
 	}
 
 	restakableDenoms, err := k.GetRestakableDenoms(ctx)
@@ -317,13 +316,12 @@ func (k *Keeper) GetServiceUnbondingDelegation(ctx context.Context, serviceID ui
 // unbonding delegation for the given user
 func (k *Keeper) UndelegateFromService(ctx context.Context, serviceID uint32, amount sdk.Coins, delegator string) (time.Time, error) {
 	// Find the service
-	service, found, err := k.servicesKeeper.GetService(ctx, serviceID)
+	service, err := k.servicesKeeper.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return time.Time{}, servicestypes.ErrServiceNotFound
+		}
 		return time.Time{}, err
-	}
-
-	if !found {
-		return time.Time{}, servicestypes.ErrServiceNotFound
 	}
 
 	// Get the shares

--- a/x/restaking/keeper/service_restaking.go
+++ b/x/restaking/keeper/service_restaking.go
@@ -27,8 +27,8 @@ func (k *Keeper) GetAllServiceAllowedOperators(ctx context.Context, serviceID ui
 	if err != nil {
 		return nil, err
 	}
-
 	defer iterator.Close()
+
 	var operators []uint32
 	for ; iterator.Valid(); iterator.Next() {
 		serviceOperatorPair, err := iterator.Key()
@@ -64,12 +64,7 @@ func (k *Keeper) IsServiceOperatorsAllowListConfigured(ctx context.Context, serv
 		return false, err
 	}
 	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		return true, nil
-	}
-
-	return false, nil
+	return iterator.Valid(), nil
 }
 
 // IsOperatorInServiceAllowList returns true if the given operator is in the
@@ -145,12 +140,7 @@ func (k *Keeper) IsServiceSecuringPoolsConfigured(ctx context.Context, serviceID
 		return false, err
 	}
 	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		return true, nil
-	}
-
-	return false, nil
+	return iterator.Valid(), nil
 }
 
 // IsPoolInServiceSecuringPools returns true if the pool is in the list

--- a/x/restaking/keeper/service_restaking_test.go
+++ b/x/restaking/keeper/service_restaking_test.go
@@ -717,9 +717,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToService() {
 			expShares: sdk.NewDecCoins(sdk.NewDecCoinFromDec("service/1/umilk", sdkmath.LegacyNewDec(500))),
 			check: func(ctx sdk.Context) {
 				// Make sure the service now exists
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.Service{
 					ID:      1,
 					Status:  servicestypes.SERVICE_STATUS_ACTIVE,
@@ -804,9 +803,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToService() {
 			expShares: sdk.NewDecCoins(sdk.NewDecCoinFromDec("service/1/uinit", sdkmath.LegacyNewDec(100))),
 			check: func(ctx sdk.Context) {
 				// Make sure the service now exists
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.Service{
 					ID:      1,
 					Status:  servicestypes.SERVICE_STATUS_ACTIVE,
@@ -912,9 +910,8 @@ func (suite *KeeperTestSuite) TestKeeper_DelegateToService() {
 			),
 			check: func(ctx sdk.Context) {
 				// Make sure the service now exists
-				service, found, err := suite.sk.GetService(ctx, 1)
+				service, err := suite.sk.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(servicestypes.Service{
 					ID:      1,
 					Status:  servicestypes.SERVICE_STATUS_ACTIVE,

--- a/x/restaking/keeper/services_hooks.go
+++ b/x/restaking/keeper/services_hooks.go
@@ -46,7 +46,7 @@ func (h *ServicesHooks) BeforeServiceDeleted(ctx context.Context, serviceID uint
 
 	// Get the iterator to iterate over the operators that are
 	// allowed to secure this service
-	serviceOperatorsAllowListIter, err := h.serviceOperatorsAllowList.Iterate(ctx, collections.NewPrefixedPairRange[uint32, uint32](serviceID))
+	serviceOperatorsAllowListIter, err := h.ServiceAllowedOperatorsIterator(ctx, serviceID)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *ServicesHooks) BeforeServiceDeleted(ctx context.Context, serviceID uint
 
 	// Get the iterator to iterate over the list of pools from
 	// which the service is allowed to borrow security
-	serviceSecuringPoolsIter, err := h.serviceSecuringPools.Iterate(ctx, collections.NewPrefixedPairRange[uint32, uint32](serviceID))
+	serviceSecuringPoolsIter, err := h.ServiceSecuringPoolsIterator(ctx, serviceID)
 	if err != nil {
 		return err
 	}

--- a/x/restaking/types/expected_keepers.go
+++ b/x/restaking/types/expected_keepers.go
@@ -24,14 +24,14 @@ type BankKeeper interface {
 type PoolsKeeper interface {
 	GetPoolByDenom(ctx context.Context, denom string) (poolstypes.Pool, bool, error)
 	CreateOrGetPoolByDenom(ctx context.Context, denom string) (poolstypes.Pool, error)
-	GetPool(ctx context.Context, poolID uint32) (poolstypes.Pool, bool, error)
+	GetPool(ctx context.Context, poolID uint32) (poolstypes.Pool, error)
 	SavePool(ctx context.Context, pool poolstypes.Pool) error
 	IteratePools(ctx context.Context, cb func(poolstypes.Pool) (bool, error)) error
 	GetPools(ctx context.Context) ([]poolstypes.Pool, error)
 }
 
 type OperatorsKeeper interface {
-	GetOperator(ctx context.Context, operatorID uint32) (operatorstypes.Operator, bool, error)
+	GetOperator(ctx context.Context, operatorID uint32) (operatorstypes.Operator, error)
 	SaveOperator(ctx context.Context, operator operatorstypes.Operator) error
 	IterateOperators(ctx context.Context, cb func(operatorstypes.Operator) (bool, error)) error
 	GetOperators(ctx context.Context) ([]operatorstypes.Operator, error)
@@ -41,7 +41,7 @@ type OperatorsKeeper interface {
 
 type ServicesKeeper interface {
 	HasService(ctx context.Context, serviceID uint32) (bool, error)
-	GetService(ctx context.Context, serviceID uint32) (servicestypes.Service, bool, error)
+	GetService(ctx context.Context, serviceID uint32) (servicestypes.Service, error)
 	SaveService(ctx context.Context, service servicestypes.Service) error
 	IterateServices(ctx context.Context, cb func(servicestypes.Service) (bool, error)) error
 	GetServices(ctx context.Context) ([]servicestypes.Service, error)

--- a/x/rewards/keeper/allocation.go
+++ b/x/rewards/keeper/allocation.go
@@ -197,13 +197,12 @@ func (k *Keeper) AllocateRewardsByPlan(
 		return err
 	}
 
-	service, found, err := k.servicesKeeper.GetService(ctx, plan.ServiceID)
+	service, err := k.servicesKeeper.GetService(ctx, plan.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return servicestypes.ErrServiceNotFound
+		}
 		return err
-	}
-
-	if !found {
-		return servicestypes.ErrServiceNotFound
 	}
 
 	// Ensure that we are distribution rewards only for active services

--- a/x/rewards/keeper/allocation_test.go
+++ b/x/rewards/keeper/allocation_test.go
@@ -970,7 +970,7 @@ func (suite *KeeperTestSuite) TestAllocateRewards_InactiveOperator() {
 	suite.Require().NoError(err)
 
 	// Refresh the updated state of operator 2.
-	operator2, _, err = suite.operatorsKeeper.GetOperator(ctx, operator2.ID)
+	operator2, err = suite.operatorsKeeper.GetOperator(ctx, operator2.ID)
 	suite.Require().NoError(err)
 	// Operator 2 becomes inactive.
 	err = suite.operatorsKeeper.StartOperatorInactivation(ctx, operator2)

--- a/x/rewards/keeper/common_test.go
+++ b/x/rewards/keeper/common_test.go
@@ -145,9 +145,8 @@ func (suite *KeeperTestSuite) CreateService(ctx sdk.Context, name string, admin 
 	_, err = servicesMsgServer.ActivateService(ctx, servicestypes.NewMsgActivateService(resp.NewServiceID, admin))
 	suite.Require().NoError(err)
 
-	service, found, err := suite.servicesKeeper.GetService(ctx, resp.NewServiceID)
+	service, err := suite.servicesKeeper.GetService(ctx, resp.NewServiceID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "service must be found")
 	return service
 }
 
@@ -167,9 +166,8 @@ func (suite *KeeperTestSuite) CreateOperator(ctx sdk.Context, name string, admin
 	suite.Require().NoError(err)
 
 	// Make sure the operator is found
-	operator, found, err := suite.operatorsKeeper.GetOperator(ctx, resp.NewOperatorID)
+	operator, err := suite.operatorsKeeper.GetOperator(ctx, resp.NewOperatorID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "operator must be found")
 	return operator
 }
 
@@ -182,9 +180,8 @@ func (suite *KeeperTestSuite) UpdateOperatorParams(
 	joinedServicesIDs []uint32,
 ) {
 	// Make sure the operator is found
-	_, found, err := suite.operatorsKeeper.GetOperator(ctx, operatorID)
+	_, err := suite.operatorsKeeper.GetOperator(ctx, operatorID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "operator must be found")
 
 	// Sets the operator commission rate
 	err = suite.operatorsKeeper.SaveOperatorParams(ctx, operatorID, operatorstypes.NewOperatorParams(commissionRate))
@@ -221,9 +218,8 @@ func (suite *KeeperTestSuite) AddPoolsToServiceSecuringPools(
 	whitelistedPoolsIDs []uint32,
 ) {
 	// Make sure the service is found
-	_, found, err := suite.servicesKeeper.GetService(ctx, serviceID)
+	_, err := suite.servicesKeeper.GetService(ctx, serviceID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "service must be found")
 
 	for _, poolID := range whitelistedPoolsIDs {
 		err := suite.restakingKeeper.AddPoolToServiceSecuringPools(ctx, serviceID, poolID)
@@ -239,9 +235,8 @@ func (suite *KeeperTestSuite) AddOperatorsToServiceAllowList(
 	allowedOperatorsID []uint32,
 ) {
 	// Make sure the service is found
-	_, found, err := suite.servicesKeeper.GetService(ctx, serviceID)
+	_, err := suite.servicesKeeper.GetService(ctx, serviceID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "service must be found")
 
 	for _, operatorID := range allowedOperatorsID {
 		err := suite.restakingKeeper.AddOperatorToServiceAllowList(ctx, serviceID, operatorID)
@@ -263,9 +258,8 @@ func (suite *KeeperTestSuite) CreateRewardsPlan(
 	usersDistr rewardstypes.UsersDistribution,
 	initialRewards sdk.Coins,
 ) rewardstypes.RewardsPlan {
-	service, found, err := suite.servicesKeeper.GetService(ctx, serviceID)
+	service, err := suite.servicesKeeper.GetService(ctx, serviceID)
 	suite.Require().NoError(err)
-	suite.Require().True(found, "service must be found")
 
 	rewardsMsgServer := keeper.NewMsgServer(suite.keeper)
 	resp, err := rewardsMsgServer.CreateRewardsPlan(ctx, rewardstypes.NewMsgCreateRewardsPlan(

--- a/x/rewards/keeper/keeper.go
+++ b/x/rewards/keeper/keeper.go
@@ -16,8 +16,7 @@ import (
 )
 
 type Keeper struct {
-	cdc          codec.Codec
-	storeService corestoretypes.KVStoreService
+	cdc codec.Codec
 
 	accountKeeper       types.AccountKeeper
 	bankKeeper          types.BankKeeper
@@ -74,7 +73,6 @@ func NewKeeper(
 	sb := collections.NewSchemaBuilder(storeService)
 	k := &Keeper{
 		cdc:                 cdc,
-		storeService:        storeService,
 		accountKeeper:       accountKeeper,
 		bankKeeper:          bankKeeper,
 		communityPoolKeeper: communityPoolKeeper,

--- a/x/rewards/keeper/msg_server.go
+++ b/x/rewards/keeper/msg_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -27,13 +28,12 @@ func NewMsgServer(k *Keeper) types.MsgServer {
 // CreateRewardsPlan defines the rpc method for Msg/CreateRewardsPlan
 func (k msgServer) CreateRewardsPlan(ctx context.Context, msg *types.MsgCreateRewardsPlan) (*types.MsgCreateRewardsPlanResponse, error) {
 	// Make sure the creator is the admin of the service
-	service, found, err := k.servicesKeeper.GetService(ctx, msg.ServiceID)
+	service, err := k.servicesKeeper.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, servicestypes.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, servicestypes.ErrServiceNotFound
 	}
 
 	if msg.Sender != service.Admin {
@@ -103,13 +103,12 @@ func (k msgServer) EditRewardsPlan(ctx context.Context, msg *types.MsgEditReward
 	}
 
 	// Get the service to which the rewards is associated
-	service, found, err := k.servicesKeeper.GetService(ctx, rewardsPlan.ServiceID)
+	service, err := k.servicesKeeper.GetService(ctx, rewardsPlan.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, servicestypes.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, servicestypes.ErrServiceNotFound
 	}
 
 	// Make sure the editor is the admin of the service
@@ -212,13 +211,12 @@ func (k msgServer) WithdrawOperatorCommission(ctx context.Context, msg *types.Ms
 		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid sender address: %s", err)
 	}
 
-	operator, found, err := k.operatorsKeeper.GetOperator(ctx, msg.OperatorID)
+	operator, err := k.operatorsKeeper.GetOperator(ctx, msg.OperatorID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, operatorstypes.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, operatorstypes.ErrOperatorNotFound
 	}
 
 	if msg.Sender != operator.Admin {

--- a/x/rewards/keeper/target.go
+++ b/x/rewards/keeper/target.go
@@ -35,12 +35,12 @@ func (k *Keeper) GetDelegationTarget(
 ) (DelegationTarget, error) {
 	switch delType {
 	case restakingtypes.DELEGATION_TYPE_POOL:
-		pool, found, err := k.poolsKeeper.GetPool(ctx, targetID)
+		pool, err := k.poolsKeeper.GetPool(ctx, targetID)
 		if err != nil {
+			if errors.IsOf(err, collections.ErrNotFound) {
+				return DelegationTarget{}, poolstypes.ErrPoolNotFound
+			}
 			return DelegationTarget{}, err
-		}
-		if !found {
-			return DelegationTarget{}, poolstypes.ErrPoolNotFound
 		}
 		return DelegationTarget{
 			DelegationTarget:       pool,
@@ -51,12 +51,12 @@ func (k *Keeper) GetDelegationTarget(
 			OutstandingRewards:     k.PoolOutstandingRewards,
 		}, nil
 	case restakingtypes.DELEGATION_TYPE_OPERATOR:
-		operator, found, err := k.operatorsKeeper.GetOperator(ctx, targetID)
+		operator, err := k.operatorsKeeper.GetOperator(ctx, targetID)
 		if err != nil {
+			if errors.IsOf(err, collections.ErrNotFound) {
+				return DelegationTarget{}, operatorstypes.ErrOperatorNotFound
+			}
 			return DelegationTarget{}, err
-		}
-		if !found {
-			return DelegationTarget{}, operatorstypes.ErrOperatorNotFound
 		}
 		return DelegationTarget{
 			DelegationTarget:       operator,
@@ -67,12 +67,12 @@ func (k *Keeper) GetDelegationTarget(
 			OutstandingRewards:     k.OperatorOutstandingRewards,
 		}, nil
 	case restakingtypes.DELEGATION_TYPE_SERVICE:
-		service, found, err := k.servicesKeeper.GetService(ctx, targetID)
+		service, err := k.servicesKeeper.GetService(ctx, targetID)
 		if err != nil {
+			if errors.IsOf(err, collections.ErrNotFound) {
+				return DelegationTarget{}, servicestypes.ErrServiceNotFound
+			}
 			return DelegationTarget{}, err
-		}
-		if !found {
-			return DelegationTarget{}, servicestypes.ErrServiceNotFound
 		}
 		return DelegationTarget{
 			DelegationTarget:       service,

--- a/x/rewards/keeper/withdraw.go
+++ b/x/rewards/keeper/withdraw.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -63,13 +65,12 @@ func (k *Keeper) WithdrawDelegationRewards(
 
 // WithdrawOperatorCommission withdraws the operator's accumulated commission
 func (k *Keeper) WithdrawOperatorCommission(ctx context.Context, operatorID uint32) (types.Pools, error) {
-	operator, found, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
+	operator, err := k.operatorsKeeper.GetOperator(ctx, operatorID)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, operatorstypes.ErrOperatorNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, operatorstypes.ErrOperatorNotFound
 	}
 
 	// Fetch the operator accumulated commission

--- a/x/rewards/types/expected_keepers.go
+++ b/x/rewards/types/expected_keepers.go
@@ -43,20 +43,20 @@ type OracleKeeper interface {
 }
 
 type PoolsKeeper interface {
-	GetPool(ctx context.Context, poolID uint32) (poolstypes.Pool, bool, error)
+	GetPool(ctx context.Context, poolID uint32) (poolstypes.Pool, error)
 	GetPools(ctx context.Context) ([]poolstypes.Pool, error)
 	IteratePools(ctx context.Context, cb func(pool poolstypes.Pool) (stop bool, err error)) error
 }
 
 type OperatorsKeeper interface {
-	GetOperator(ctx context.Context, operatorID uint32) (operatorstypes.Operator, bool, error)
+	GetOperator(ctx context.Context, operatorID uint32) (operatorstypes.Operator, error)
 	GetOperators(ctx context.Context) ([]operatorstypes.Operator, error)
 	IterateOperators(ctx context.Context, cb func(operator operatorstypes.Operator) (stop bool, err error)) error
 	GetOperatorParams(ctx context.Context, operatorID uint32) (operatorstypes.OperatorParams, error)
 }
 
 type ServicesKeeper interface {
-	GetService(ctx context.Context, serviceID uint32) (servicestypes.Service, bool, error)
+	GetService(ctx context.Context, serviceID uint32) (servicestypes.Service, error)
 	GetServiceParams(ctx context.Context, serviceID uint32) (servicestypes.ServiceParams, error)
 	IterateServices(ctx context.Context, cb func(service servicestypes.Service) (stop bool, err error)) error
 }

--- a/x/services/keeper/alias_functions.go
+++ b/x/services/keeper/alias_functions.go
@@ -19,29 +19,10 @@ func (k *Keeper) createAccountIfNotExists(ctx context.Context, address sdk.AccAd
 
 // IterateServices iterates over the services in the store and performs a callback function
 func (k *Keeper) IterateServices(ctx context.Context, cb func(service types.Service) (stop bool, err error)) error {
-	iterator, err := k.services.Iterate(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		service, err := iterator.Value()
-		if err != nil {
-			return err
-		}
-
-		stop, err := cb(service)
-		if err != nil {
-			return err
-		}
-
-		if stop {
-			break
-		}
-	}
-
-	return nil
+	err := k.services.Walk(ctx, nil, func(_ uint32, service types.Service) (stop bool, err error) {
+		return cb(service)
+	})
+	return err
 }
 
 // GetServices returns the services stored in the KVStore

--- a/x/services/keeper/keeper.go
+++ b/x/services/keeper/keeper.go
@@ -19,8 +19,7 @@ type Keeper struct {
 	accountKeeper types.AccountKeeper
 	poolKeeper    types.CommunityPoolKeeper
 
-	storeService corestoretypes.KVStoreService
-	Schema       collections.Schema
+	Schema collections.Schema
 
 	nextServiceID     collections.Sequence                         // Next service ID
 	services          collections.Map[uint32, types.Service]       // service ID -> service
@@ -48,7 +47,6 @@ func NewKeeper(
 		accountKeeper: accountKeeper,
 		poolKeeper:    poolKeeper,
 		authority:     authority,
-		storeService:  storeService,
 
 		nextServiceID: collections.NewSequence(
 			sb,

--- a/x/services/keeper/msg_server.go
+++ b/x/services/keeper/msg_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -104,13 +105,12 @@ func (k msgServer) CreateService(goCtx context.Context, msg *types.MsgCreateServ
 // UpdateService defines the rpc method for Msg/UpdateService
 func (k msgServer) UpdateService(ctx context.Context, msg *types.MsgUpdateService) (*types.MsgUpdateServiceResponse, error) {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "service with id %d not found", msg.ServiceID)
 	}
 
 	// Make sure the user that is updating the service is the admin
@@ -146,13 +146,12 @@ func (k msgServer) UpdateService(ctx context.Context, msg *types.MsgUpdateServic
 
 func (k msgServer) ActivateService(ctx context.Context, msg *types.MsgActivateService) (*types.MsgActivateServiceResponse, error) {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, errors.Wrapf(types.ErrServiceNotFound, "service with id %d not found", msg.ServiceID)
 	}
 
 	// Make sure the user that is activating the service is the admin
@@ -181,13 +180,12 @@ func (k msgServer) ActivateService(ctx context.Context, msg *types.MsgActivateSe
 // DeactivateService defines the rpc method for Msg/DeactivateService
 func (k msgServer) DeactivateService(ctx context.Context, msg *types.MsgDeactivateService) (*types.MsgDeactivateServiceResponse, error) {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, errors.Wrapf(types.ErrServiceNotFound, "service with id %d not found", msg.ServiceID)
 	}
 
 	// Make sure the user that is deactivating the service is the admin
@@ -215,13 +213,12 @@ func (k msgServer) DeactivateService(ctx context.Context, msg *types.MsgDeactiva
 
 func (k msgServer) DeleteService(ctx context.Context, msg *types.MsgDeleteService) (*types.MsgDeleteServiceResponse, error) {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, errors.Wrapf(types.ErrServiceNotFound, "service with id %d not found", msg.ServiceID)
 	}
 
 	// Make sure the user that is deleting the service is the admin
@@ -250,13 +247,12 @@ func (k msgServer) DeleteService(ctx context.Context, msg *types.MsgDeleteServic
 // TransferServiceOwnership defines the rpc method for Msg/TransferServiceOwnership
 func (k msgServer) TransferServiceOwnership(ctx context.Context, msg *types.MsgTransferServiceOwnership) (*types.MsgTransferServiceOwnershipResponse, error) {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrServiceNotFound
 	}
 
 	// Make sure only the admin can transfer the service ownership
@@ -286,13 +282,12 @@ func (k msgServer) TransferServiceOwnership(ctx context.Context, msg *types.MsgT
 // SetServiceParams define the rpc method for Msg/SetServiceParams
 func (k msgServer) SetServiceParams(ctx context.Context, msg *types.MsgSetServiceParams) (*types.MsgSetServiceParamsResponse, error) {
 	// Get the service whose params are being set
-	service, found, err := k.GetService(ctx, msg.ServiceID)
+	service, err := k.GetService(ctx, msg.ServiceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return nil, types.ErrServiceNotFound
+		}
 		return nil, err
-	}
-
-	if !found {
-		return nil, types.ErrServiceNotFound
 	}
 
 	// Ensure the sender is the service admin

--- a/x/services/keeper/msg_server_test.go
+++ b/x/services/keeper/msg_server_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -118,9 +119,8 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service has been stored
-				stored, found, err := suite.k.GetService(ctx, 1)
+				stored, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_CREATED,
@@ -200,9 +200,8 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service has been stored
-				stored, found, err := suite.k.GetService(ctx, 1)
+				stored, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_CREATED,
@@ -386,9 +385,8 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service was updated
-				stored, found, err := suite.k.GetService(ctx, 1)
+				stored, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_CREATED,
@@ -632,9 +630,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeactivateService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service was deactivated
-				stored, found, err := suite.k.GetService(ctx, 1)
+				stored, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_INACTIVE,
@@ -770,9 +767,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service was removed
-				_, found, err := suite.k.GetService(ctx, 1)
-				suite.Require().NoError(err)
-				suite.Require().False(found)
+				_, err := suite.k.GetService(ctx, 1)
+				suite.Require().ErrorIs(err, collections.ErrNotFound)
 			},
 		},
 		{
@@ -803,9 +799,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteService() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service was removed
-				_, found, err := suite.k.GetService(ctx, 1)
-				suite.Require().NoError(err)
-				suite.Require().False(found)
+				_, err := suite.k.GetService(ctx, 1)
+				suite.Require().ErrorIs(err, collections.ErrNotFound)
 			},
 		},
 	}
@@ -914,9 +909,8 @@ func (suite *KeeperTestSuite) TestMsgServer_TransferServiceOwnership() {
 			},
 			check: func(ctx sdk.Context) {
 				// Make sure the service was updated
-				stored, found, err := suite.k.GetService(ctx, 1)
+				stored, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_ACTIVE,
@@ -1228,9 +1222,8 @@ func (suite *KeeperTestSuite) TestMsgServer_AccreditService() {
 				),
 			},
 			check: func(ctx sdk.Context) {
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().True(service.Accredited)
 			},
 		},
@@ -1325,9 +1318,8 @@ func (suite *KeeperTestSuite) TestMsgService_RevokeServiceAccreditation() {
 				),
 			},
 			check: func(ctx sdk.Context) {
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().False(service.Accredited)
 			},
 		},

--- a/x/services/keeper/services.go
+++ b/x/services/keeper/services.go
@@ -64,13 +64,12 @@ func (k *Keeper) CreateService(ctx context.Context, service types.Service) error
 
 // ActivateService activates the service with the given ID
 func (k *Keeper) ActivateService(ctx context.Context, serviceID uint32) error {
-	service, found, err := k.GetService(ctx, serviceID)
+	service, err := k.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return types.ErrServiceNotFound
+		}
 		return err
-	}
-
-	if !found {
-		return types.ErrServiceNotFound
 	}
 
 	// Check if the service is already active
@@ -93,13 +92,12 @@ func (k *Keeper) ActivateService(ctx context.Context, serviceID uint32) error {
 
 // DeactivateService deactivates the service with the given ID
 func (k *Keeper) DeactivateService(ctx context.Context, serviceID uint32) error {
-	service, exists, err := k.GetService(ctx, serviceID)
+	service, err := k.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return types.ErrServiceNotFound
+		}
 		return err
-	}
-
-	if !exists {
-		return types.ErrServiceNotFound
 	}
 
 	// Make sure the service is active
@@ -121,13 +119,12 @@ func (k *Keeper) DeactivateService(ctx context.Context, serviceID uint32) error 
 
 // DeleteService deletes the service with the given ID
 func (k *Keeper) DeleteService(ctx context.Context, serviceID uint32) error {
-	service, exists, err := k.GetService(ctx, serviceID)
+	service, err := k.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return types.ErrServiceNotFound
+		}
 		return err
-	}
-
-	if !exists {
-		return types.ErrServiceNotFound
 	}
 
 	// Make sure the service is not active
@@ -153,13 +150,12 @@ func (k *Keeper) DeleteService(ctx context.Context, serviceID uint32) error {
 // SetServiceAccredited sets the accreditation of the service with the given ID
 func (k *Keeper) SetServiceAccredited(ctx context.Context, serviceID uint32, accredited bool) error {
 	// Check if the service exists
-	service, found, err := k.GetService(ctx, serviceID)
+	service, err := k.GetService(ctx, serviceID)
 	if err != nil {
+		if errors.IsOf(err, collections.ErrNotFound) {
+			return types.ErrServiceNotFound
+		}
 		return err
-	}
-
-	if !found {
-		return errors.Wrapf(types.ErrServiceNotFound, "service with id %d not found", serviceID)
 	}
 
 	// Skip any operation if the service accreditation status does not change
@@ -184,15 +180,8 @@ func (k *Keeper) HasService(ctx context.Context, serviceID uint32) (bool, error)
 }
 
 // GetService returns an Service from the KVStore
-func (k *Keeper) GetService(ctx context.Context, serviceID uint32) (service types.Service, found bool, err error) {
-	service, err = k.services.Get(ctx, serviceID)
-	if err != nil {
-		if errors.IsOf(err, collections.ErrNotFound) {
-			return service, false, nil
-		}
-		return service, false, err
-	}
-	return service, true, nil
+func (k *Keeper) GetService(ctx context.Context, serviceID uint32) (service types.Service, err error) {
+	return k.services.Get(ctx, serviceID)
 }
 
 // GetServiceParams returns the params for the service with the given ID

--- a/x/services/keeper/services_test.go
+++ b/x/services/keeper/services_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -145,9 +146,8 @@ func (suite *KeeperTestSuite) TestKeeper_CreateService() {
 				suite.Require().True(hasAccount)
 
 				// Make sure the service has been created
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_ACTIVE,
@@ -240,9 +240,8 @@ func (suite *KeeperTestSuite) TestKeeper_ActivateService() {
 			serviceID: 1,
 			shouldErr: false,
 			check: func(ctx sdk.Context) {
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_ACTIVE,
@@ -335,9 +334,8 @@ func (suite *KeeperTestSuite) TestKeeper_DeactivateService() {
 			serviceID: 1,
 			shouldErr: false,
 			check: func(ctx sdk.Context) {
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().Equal(types.NewService(
 					1,
 					types.SERVICE_STATUS_INACTIVE,
@@ -415,9 +413,8 @@ func (suite *KeeperTestSuite) TestKeeper_SetServiceAccreditation() {
 			shouldErr:  false,
 			check: func(ctx sdk.Context) {
 				// Accreditation didn't change
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().False(service.Accredited)
 
 				// Make sure the hook wasn't called
@@ -444,9 +441,8 @@ func (suite *KeeperTestSuite) TestKeeper_SetServiceAccreditation() {
 			shouldErr:  false,
 			check: func(ctx sdk.Context) {
 				// Accreditation changed
-				service, found, err := suite.k.GetService(ctx, 1)
+				service, err := suite.k.GetService(ctx, 1)
 				suite.Require().NoError(err)
-				suite.Require().True(found)
 				suite.Require().True(service.Accredited)
 
 				// Make sure the hook was called
@@ -485,14 +481,12 @@ func (suite *KeeperTestSuite) TestKeeper_GetService() {
 		name       string
 		store      func(ctx sdk.Context)
 		serviceID  uint32
-		shouldErr  bool
 		expFound   bool
 		expService types.Service
 	}{
 		{
 			name:      "service not found returns false",
 			serviceID: 1,
-			shouldErr: false,
 			expFound:  false,
 		},
 		{
@@ -511,7 +505,6 @@ func (suite *KeeperTestSuite) TestKeeper_GetService() {
 				suite.Require().NoError(err)
 			},
 			serviceID: 1,
-			shouldErr: false,
 			expFound:  true,
 			expService: types.NewService(
 				1,
@@ -534,18 +527,12 @@ func (suite *KeeperTestSuite) TestKeeper_GetService() {
 				tc.store(ctx)
 			}
 
-			service, found, err := suite.k.GetService(ctx, tc.serviceID)
-			if tc.shouldErr {
-				suite.Require().Error(err)
+			service, err := suite.k.GetService(ctx, tc.serviceID)
+			if !tc.expFound {
+				suite.Require().ErrorIs(err, collections.ErrNotFound)
 			} else {
 				suite.Require().NoError(err)
-
-				if !tc.expFound {
-					suite.Require().False(found)
-				} else {
-					suite.Require().True(found)
-					suite.Require().Equal(tc.expService, service)
-				}
+				suite.Require().Equal(tc.expService, service)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The main changes are:
- Use `Walk()` instead of old iterator-based approaches where applicable
- Return an error only instead of a bit of redundant `(T, bool error)`
- Remove unused `storeService` references in keepers

This PR introduces no state-breaking changes but note that merging this PR is not urgent.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)