### PR TITLE
fix: allow to add non MilkyWay address to the trusted delegates

### DIFF
--- a/x/liquidvesting/keeper/msg_server_test.go
+++ b/x/liquidvesting/keeper/msg_server_test.go
@@ -404,6 +404,30 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateParams() {
 			),
 			shouldErr: true,
 		},
+		{
+			name: "trust delegates with invalid bech32 prefix returns error",
+			msg: types.NewMsgUpdateParams(
+				authtypes.NewModuleAddress("gov").String(),
+				types.NewParams(math.LegacyNewDec(2), nil, nil, []string{"invalid"}, nil),
+			),
+			shouldErr: true,
+		},
+		{
+			name: "trust delegates with different bech32 prefix are allowed",
+			msg: types.NewMsgUpdateParams(
+				authtypes.NewModuleAddress("gov").String(),
+				types.NewParams(math.LegacyNewDec(2), nil, nil, []string{"celestia102lq49sg6lmw2e0mw740tjldzq68v0yfhj2vst"}, nil),
+			),
+			shouldErr: false,
+			expEvents: sdk.Events{},
+			check: func(ctx sdk.Context) {
+				params, err := suite.k.GetParams(ctx)
+				suite.Assert().NoError(err)
+
+				expParams := types.NewParams(math.LegacyNewDec(2), nil, nil, []string{"celestia102lq49sg6lmw2e0mw740tjldzq68v0yfhj2vst"}, nil)
+				suite.Assert().Equal(expParams, params)
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/liquidvesting/types/params.go
+++ b/x/liquidvesting/types/params.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 )
 
@@ -49,7 +50,7 @@ func (p *Params) Validate() error {
 		}
 	}
 	for _, address := range p.TrustedDelegates {
-		_, err := sdk.AccAddressFromBech32(address)
+		_, _, err := bech32.DecodeAndConvert(address)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR fixes a bug that prevents adding non-MilkyWay addresses to the `TrustedDelegates` of the `x/liquidvesting` module, which blocks deposits from other chains.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)