### PR TITLE
fix(tests): fix simulation test invalid genesis state

### DIFF
--- a/x/rewards/simulation/genesis.go
+++ b/x/rewards/simulation/genesis.go
@@ -40,7 +40,11 @@ func RandomizedGenState(simState *module.SimulationState) {
 		types.NewDelegationTypeRecords(nil, nil, nil, nil),
 		types.NewDelegationTypeRecords(nil, nil, nil, nil),
 		types.NewDelegationTypeRecords(nil, nil, nil, nil),
-		RandomOperatorAccumulatedCommissionRecords(simState.Rand, operatorsGenesis.Operators, []string{simState.BondDenom}),
+
+		// Empty accumulated commissions since we need to perform side effects on
+		// other modules to have valid commissions
+		nil,
+
 		RandomPoolServiceTotalDelegatorShares(simState.Rand, poolsGenesis, servicesGenesis, []string{simState.BondDenom}),
 	)
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(genesis)


### PR DESCRIPTION
## Description

This PR fixes the simulation tests by removing invalid `x/rewards` genesis accumulated commissions initialization. 

The previous code created random accumulated commissions for random targets. However, this caused the following error when running some simulations:

```
Simulating... block 2/100, operation 100/237. Logs to writing to $HOME/.simapp/simulations/1734395338592.log
    simulate.go:345: error on block  2/100, operation (138/237) from x/operators:
        recovered: negative coin amount
````

This error was raised while trying to execute a `MsgDeleteOperator` on an operator that had some accumulated commissions, but whose outstanding rewards were empty. When running the clean up code, the error would be raised since the outstanding would be zero:

```go
// Subtract from outstanding
outstanding = outstanding.Sub(commission)
```

This could be verified running the determinism tests with seed `2282874401958575228`: 

```
go test -mod=readonly ./app -run TestAppStateDeterminism -Enabled=true \
	-Seed 2282874401958575228 -NumBlocks=100 -BlockSize=200 \
	-Commit=true -Period=0 -v -timeout 24h
```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)