### PR TITLE
fix: fix connect price oracle's tx parse error

### DIFF
--- a/cmd/milkywayd/cmd/config.go
+++ b/cmd/milkywayd/cmd/config.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// fallbackTxConfig is a wrapper around the client.TxConfig interface that
+// provides a custom TxDecoder function.
+type fallbackTxConfig struct {
+	client.TxConfig
+}
+
+// NewClientTxConfig creates a new instance of fallbackTxConfig
+func newFallbackTxConfig(txConfig client.TxConfig) client.TxConfig {
+	return fallbackTxConfig{txConfig}
+}
+
+// TxDecoder returns a custom TxDecoder function that handles decoding failed
+// transactions. This is needed to handle connect price oracle's pseudo txs.
+func (c fallbackTxConfig) TxDecoder() sdk.TxDecoder {
+	return func(txBytes []byte) (sdk.Tx, error) {
+		if tx, err := c.TxConfig.TxDecoder()(txBytes); err != nil {
+			txBuilder := c.NewTxBuilder()
+			txBuilder.SetMemo("decode failed tx")
+
+			return txBuilder.GetTx(), nil
+		} else {
+			return tx, err
+		}
+	}
+}

--- a/cmd/milkywayd/cmd/root.go
+++ b/cmd/milkywayd/cmd/root.go
@@ -95,6 +95,7 @@ func NewRootCmd() *cobra.Command {
 	initClientCtx := client.Context{}.
 		WithCodec(tempApplication.AppCodec()).
 		WithInterfaceRegistry(tempApplication.InterfaceRegistry()).
+		WithTxConfig(newFallbackTxConfig(tempApplication.GetTxConfig())).
 		WithLegacyAmino(tempApplication.LegacyAmino()).
 		WithInput(os.Stdin).
 		WithAccountRetriever(types.AccountRetriever{}).
@@ -134,7 +135,7 @@ func NewRootCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				initClientCtx = initClientCtx.WithTxConfig(txConfigWithTextual)
+				initClientCtx = initClientCtx.WithTxConfig(newFallbackTxConfig(txConfigWithTextual))
 			}
 
 			if err = client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {


### PR DESCRIPTION
## Description

Skip's connect price oracle inserts a pseudo tx as the first tx of every block which cannot be parsed. This PR adds a wrapper around `TxConfig` which ignores the tx decoding error and simply puts a memo upon tx decoding.

Currently, `/cosmos/tx/v1beta1/txs?query=tx.height=...` API returns:
```json
{
  "code": 13,
  "message": "expected 2 wire type, got 0: tx parse error",
  "details": []
}
```

After merging this PR it'll return:
```json
{
  "txs": [
    {
      "body": {
        "messages": [],
        "memo": "decode failed tx",
        "timeout_height": "0",
        "extension_options": [],
        "non_critical_extension_options": []
      },
      "auth_info": {
        "signer_infos": [],
        "fee": {
          "amount": [],
          "gas_limit": "0",
          "payer": "",
          "granter": ""
        },
        "tip": null
      },
      "signatures": []
    }
  ],
  "tx_responses": [
    {
      "height": "...",
      "txhash": "...",
      "codespace": "sdk",
      "code": 2,
      "data": "",
      "raw_log": "tx parse error",
      "logs": [],
      "info": "",
      "gas_wanted": "0",
      "gas_used": "0",
      "tx": {
        "@type": "/cosmos.tx.v1beta1.Tx",
        "body": {
          "messages": [],
          "memo": "decode failed tx",
          "timeout_height": "0",
          "extension_options": [],
          "non_critical_extension_options": []
        },
        "auth_info": {
          "signer_infos": [],
          "fee": {
            "amount": [],
            "gas_limit": "0",
            "payer": "",
            "granter": ""
          },
          "tip": null
        },
        "signatures": []
      },
      "timestamp": "...",
      "events": []
    }
  ],
  "pagination": null,
  "total": "1"
}
```

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/milkyway-labs/milkyway/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved transaction decoding to gracefully handle certain special or malformed transactions by providing a fallback mechanism, ensuring the application remains stable even if some transactions cannot be decoded normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->